### PR TITLE
fix: ingest parsing uses first positional as model

### DIFF
--- a/cmd/ocnlp/main.go
+++ b/cmd/ocnlp/main.go
@@ -75,10 +75,12 @@ func main() {
 				args = append(args, a)
 			}
 		}
-		if len(args) < 2 {
+		if len(args) < 1 {
 			log.Fatal("usage: ocnlp ingest <model> --path <file|dir> [--data .ocnlp]")
 		}
-		model := args[1]
+		model := args[0]
+		// ignore any extra positional args (often introduced by shell completion)
+
 		if path == "" {
 			log.Fatal("missing --path")
 		}


### PR DESCRIPTION
Fixes ingest CLI parsing: model is the first positional arg after . Also tolerates extra positional args that can be introduced by shell completion.